### PR TITLE
feat: 🎸 Support `sea_orm::ColumnTrait` with fully-qualification

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,33 +2,87 @@ name: "Test"
 
 on: [push]
 
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+
 jobs:
   rust-test:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        sea-query: ["0.30", "0.31"]
-        sqlx: ["0.7", "0.8"]
+        sea:
+          - { sea-orm: "1.0", sea-query: "0.31" }
+        use-sea-orm:
+          - true
+          - false
+        sqlx:
+          - "0.7"
+          - "0.8"
+        exclude:
+          - sea: { sea-orm: "1.0", sea-query: "0.31" }
+            use-sea-orm: true
+            sqlx: "0.8"
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust stable toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
+      - name: Install Coverage Tools
+        if: ${{ matrix.use-sea-orm }}
+        run: |
+          rustup component add llvm-tools-preview --toolchain nightly
+          cargo +nightly install cargo-llvm-cov
       - name: Update dependencies
         run: |
-          cargo add sea-query@${{ matrix.sea-query }}
-          cargo add --dev sqlx@${{ matrix.sqlx }}
-          cargo add --dev sqlx-postgres@${{ matrix.sqlx }}
+          cargo remove sea-orm sea-query
+          cargo remove --dev sea-orm sea-query sqlx sqlx-postgres
+          cargo add sea-query@${{ matrix.sea.sea-query }} --no-default-features
+          cargo add --dev sea-query@${{ matrix.sea.sea-query }}
+          if [ "${{ matrix.use-sea-orm }}" == "true" ]; then
+            cargo add sea-orm@${{ matrix.sea.sea-orm }} --no-default-features --optional
+            cargo add --dev sea-orm@${{ matrix.sea.sea-orm }} --features macros
+          fi
+          cargo add --dev sqlx@${{ matrix.sqlx }} sqlx-postgres@${{ matrix.sqlx }}
+          cat << EOF >> "$GITHUB_STEP_SUMMARY"
+          ## \`Cargo.toml\`
+          \`\`\`toml
+          $(cat Cargo.toml)
+          \`\`\`
+          EOF
+      - name: Generate feature flags
+        id: generate-flags
+        run: |
+          if [ "${{ matrix.use-sea-orm }}" == "true" ]; then
+            echo "feature_flags=--all-features" >> "$GITHUB_OUTPUT"
+          else
+            echo "feature_flags=" >> "$GITHUB_OUTPUT"
+          fi
       - name: Restore cache
         uses: Swatinem/rust-cache@v2
       - name: Check code (dependencies only)
-        run: cargo +nightly check
+        run: cargo +nightly check ${{ steps.generate-flags.outputs.feature_flags }}
       - name: Check code (with dev-dependencies)
-        run: cargo +nightly check --all-targets
+        run: cargo +nightly check --all-targets ${{ steps.generate-flags.outputs.feature_flags }}
       - name: Check test
-        run: cargo +nightly test
+        run: |
+          if [ "${{ matrix.use-sea-orm }}" == "true" ]; then
+            cargo +nightly llvm-cov ${{ steps.generate-flags.outputs.feature_flags }} --doctests --lcov >> /tmp/coverage.lcov
+          else
+            cargo test ${{ steps.generate-flags.outputs.feature_flags }}
+          fi
+      - name: Coveralls Parallel
+        if: ${{ matrix.use-sea-orm }}
+        uses: coverallsapp/github-action@v2
+        with:
+          files: /tmp/coverage.lcov
+          flag-name: >-
+            sea-orm:${{ matrix.sea.sea-orm }}
+            sea-query:${{ matrix.sea.sea-query }}
+            sqlx:${{ matrix.sqlx }}
+          parallel: true
 
   rust-lint:
     timeout-minutes: 10
@@ -48,6 +102,16 @@ jobs:
       - name: Check format
         run: cargo +nightly fmt --all -- --check
       - name: Check clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-features -- -D warnings
       - name: Check sort
         run: cargo sort -w -c
+
+  aggregate-coverages:
+    needs: rust-test
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel-finished: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sea-query-common-like"
-version = "0.1.4"
+version = "1.0.0"
 authors = ["mpyw <mpyw628@gmail.com>"]
 edition = "2021"
 rust-version = "1.80.0"
@@ -8,16 +8,26 @@ description = "A Rust crate for enhancing sea_query with typical LIKE search sup
 repository = "https://github.com/yumemi-inc/sea-query-common-like"
 license = "MIT"
 include = ["/src", "LICENSE"]
-keywords = ["sea_query", "sql", "database", "LIKE", "search"]
+keywords = ["sea-orm", "sea-query", "sql", "LIKE", "search"]
 categories = ["database", "web-programming"]
 
 [dependencies]
 fancy-regex = { version = "0.13", default-features = false }
 regex = { version = "1", default-features = false, features = ["unicode-gencat"] }
-sea-query = { version = ">=0.30, <0.32", default-features = false }
+sea-orm = { version = ">=1.0, <1.1", default-features = false, optional = true }
+sea-query = { version = ">=0.31, <0.32", default-features = false }
 
 [dev-dependencies]
-sea-query = ">=0.30, <0.32"
+sea-orm = { version = ">=1.0, <1.1", features = ["macros"] }
+sea-query = ">=0.31, <0.32"
 sqlformat = "0.2.4"
 sqlx = ">=0.7, <0.9"
 sqlx-postgres = ">=0.7, <0.9"
+
+[features]
+default = []
+with-sea-orm = ["dep:sea-orm"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # sea-query-common-like
 
+[![Coverage Status](https://coveralls.io/repos/github/yumemi-inc/sea-query-common-like/badge.svg?branch=support-sea-orm)](https://coveralls.io/github/yumemi-inc/sea-query-common-like?branch=support-sea-orm)
+
 A Rust crate for enhancing [`sea_query`](https://docs.rs/sea-query/latest/sea_query/) with typical `LIKE` search support, including escape sequences for patterns (`%fuzzy%`, `prefix%`, `%suffix`) and multi-column fuzzy search.
 
 - Documentation: [sea_query_common_like - Rust](https://docs.rs/sea-query-common-like/latest/sea_query_common_like/)


### PR DESCRIPTION
### Pull Request Summary

This pull request includes the following changes:

- **Addition of Fully-Qualified Condition Generation using `sea_orm::ColumnTrait`:**
  - New methods have been added to allow the generation of `LIKE` search conditions using fully-qualified column names when using `sea-orm`.
  - The following methods have been added:
    - `into_condition_for_orm_column`: Generates a condition using a `LIKE` pattern for a single column.
    - `into_condition_for_orm_columns`: Generates conditions using `LIKE` patterns for multiple columns.
  - These methods help create fully-qualified conditions within SQL queries using `sea-orm` columns.

- **Introduction of Feature Flags in `Cargo.toml`:**
  - A new feature flag `with-sea-orm` has been introduced to control whether or not the integration with `sea-orm` is enabled.
  - By default, this feature flag is disabled, and it needs to be explicitly enabled to use `sea-orm` related functionality. This feature flag directly impacts the availability of the fully-qualified condition generation methods mentioned above.

- **Coverage Recording and Upload to Coveralls:**
  - The GitHub Actions test workflow now records coverage and uploads it to Coveralls.

- **Version Update:**
  - The version has been updated to `1.0.0` with this release.