### PR TITLE
[Claude] Add release workflow for crates.io publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,96 @@
+name: Release
+
+on:
+  release:
+    types: [created]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run tests
+        run: cargo test --all-features
+
+      - name: Verify package
+        run: cargo publish --dry-run
+
+      - name: Get previous tag
+        id: prev_tag
+        run: |
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          echo "tag=$PREV_TAG" >> $GITHUB_OUTPUT
+
+      - name: Generate diff for approval
+        run: |
+          CURRENT_TAG="${{ github.event.release.tag_name }}"
+          PREV_TAG="${{ steps.prev_tag.outputs.tag }}"
+
+          echo "## Changes in $CURRENT_TAG" > diff_output.md
+          echo "" >> diff_output.md
+
+          if [ -z "$PREV_TAG" ]; then
+            echo "First release - showing all files:" >> diff_output.md
+            echo "" >> diff_output.md
+            for file in $(git ls-files '*.rs' 'Cargo.toml'); do
+              echo "### \`$file\`" >> diff_output.md
+              echo '```rust' >> diff_output.md
+              head -100 "$file" >> diff_output.md
+              echo '```' >> diff_output.md
+              echo "" >> diff_output.md
+            done
+          else
+            echo "Comparing \`$PREV_TAG\` → \`$CURRENT_TAG\`" >> diff_output.md
+            echo "" >> diff_output.md
+
+            CHANGED_FILES=$(git diff --name-only "$PREV_TAG" HEAD -- '*.rs' 'Cargo.toml' 2>/dev/null || echo "")
+
+            if [ -z "$CHANGED_FILES" ]; then
+              echo "No source file changes detected." >> diff_output.md
+            else
+              for file in $CHANGED_FILES; do
+                echo "### \`$file\`" >> diff_output.md
+                echo '```diff' >> diff_output.md
+                git diff "$PREV_TAG" HEAD -- "$file" >> diff_output.md
+                echo '```' >> diff_output.md
+                echo "" >> diff_output.md
+              done
+            fi
+          fi
+
+          cat diff_output.md
+
+      - name: Request approval
+        uses: trstringer/manual-approval@v1
+        with:
+          secret: ${{ github.TOKEN }}
+          approvers: mpyw
+          minimum-approvals: 1
+          issue-title: "Approve crates.io publish: ${{ github.event.release.tag_name }}"
+          issue-body: |
+            Release **${{ github.event.release.tag_name }}** is ready to be published to crates.io.
+
+            Please review the changes and comment `approve` or `deny`.
+          issue-body-file-path: diff_output.md
+          additional-approved-words: "lgtm,ship it"
+          exclude-workflow-initiator-as-approver: false
+
+      - name: Publish to crates.io
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release.yaml` for automated crates.io publishing
- Triggers when a GitHub release is created
- Runs tests before publishing

## Required Setup
**Repository secret required:**
- `CARGO_REGISTRY_TOKEN` - API token from crates.io

### How to get the token:
1. Go to https://crates.io/settings/tokens
2. Create a new token with `publish-update` scope
3. Add it as a repository secret in GitHub Settings → Secrets and variables → Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Closes #4