### PR TITLE
chore: Migrate repo references to mpyw org and widen dep ranges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["mpyw <mpyw628@gmail.com>"]
 edition = "2021"
 rust-version = "1.80.0"
 description = "A Rust crate for enhancing sea_query with typical LIKE search support, including escape sequences for patterns (%fuzzy%, prefix%, %suffix) and multi-column fuzzy search."
-repository = "https://github.com/yumemi-inc/sea-query-common-like"
+repository = "https://github.com/mpyw/sea-query-common-like"
 license = "MIT"
 include = ["/src", "LICENSE"]
 keywords = ["sea-orm", "sea-query", "sql", "LIKE", "search"]
@@ -20,7 +20,7 @@ default = []
 with-sea-orm = ["dep:sea-orm"]
 
 [dependencies]
-fancy-regex = { version = ">=0.13, <0.15", default-features = false }
+fancy-regex = { version = ">=0.13, <0.19", default-features = false }
 regex = { version = "1", default-features = false, features = ["unicode-gencat"] }
 sea-orm = { version = ">=1.0, <1.2", default-features = false, optional = true }
 sea-query = { version = ">=0.31, <0.33", default-features = false }
@@ -28,6 +28,6 @@ sea-query = { version = ">=0.31, <0.33", default-features = false }
 [dev-dependencies]
 sea-orm = { version = ">=1.0, <1.2", features = ["macros"] }
 sea-query = ">=0.31, <0.33"
-sqlformat = "0.3.5"
+sqlformat = ">=0.3.5, <0.6"
 sqlx = ">=0.7, <0.9"
 sqlx-postgres = ">=0.7, <0.9"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2024 YUMEMI Inc.
+Copyright (c) 2026 mpyw
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sea-query-common-like
 
-[![Coverage Status](https://coveralls.io/repos/github/yumemi-inc/sea-query-common-like/badge.svg?branch=support-sea-orm)](https://coveralls.io/github/yumemi-inc/sea-query-common-like?branch=support-sea-orm)
+[![Coverage Status](https://coveralls.io/repos/github/mpyw/sea-query-common-like/badge.svg?branch=main)](https://coveralls.io/github/mpyw/sea-query-common-like?branch=main)
 
 A Rust crate for enhancing [`sea_query`](https://docs.rs/sea-query/latest/sea_query/) with typical `LIKE` search support, including escape sequences for patterns (`%fuzzy%`, `prefix%`, `%suffix`) and multi-column fuzzy search.
 


### PR DESCRIPTION
## Summary
- リポジトリが `yumemi-inc` → `mpyw` に移管したことに伴うハードコード参照の更新
  - `Cargo.toml` の `repository` URL
  - `README.md` の Coveralls バッジ（org とブランチ名 `support-sea-orm` → `main`）
  - `LICENSE` に `Copyright (c) 2026 mpyw` を併記（YUMEMI Inc. 時代の表記は履歴として残置）
- 依存バージョン範囲の更新
  - `fancy-regex`: `>=0.13, <0.15` → `>=0.13, <0.19`（最新 0.18 をカバー）
  - `sqlformat`: `0.3.5` → `>=0.3.5, <0.6`（最新 0.5 をカバー）

`sea-orm` (`>=1.0, <1.2`) と `sea-query` (`>=0.31, <0.33`) は最新安定版 1.1.20 / 0.32.7 を既にカバーしているため変更なし。次期メジャー (`sea-orm 2.0`, `sea-query 1.0`) は現在 RC のため、対応は別途検討予定。

## Test plan
- [ ] CI matrix (rust-test) が全 cell green
- [ ] clippy / fmt / cargo-sort が pass
- [ ] Coveralls バッジが新 org の URL でレンダリングされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)