### PR TITLE
chore: 🤖 Bump version to 1.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sea-query-common-like"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["mpyw <mpyw628@gmail.com>"]
 edition = "2021"
 rust-version = "1.80.0"


### PR DESCRIPTION
## Summary
- `Cargo.toml` の version を `1.1.0` → `1.1.1` に bump
- 含まれる変更: #15 (repo migration to mpyw org + dep range widening)

## Test plan
- [ ] CI が green
- [ ] マージ後、`1.1.1` タグを切ってリリース作成 → release workflow による crates.io publish 承認フローに進む

🤖 Generated with [Claude Code](https://claude.com/claude-code)